### PR TITLE
add turn and speaker embeddings to bart model to model conversational…

### DIFF
--- a/src/transformers/models/bart/configuration_bart.py
+++ b/src/transformers/models/bart/configuration_bart.py
@@ -99,6 +99,12 @@ class BartConfig(PretrainedConfig):
         decoder_layerdrop: (:obj:`float`, `optional`, defaults to 0.0):
             The LayerDrop probability for the decoder. See the `LayerDrop paper <see
             https://arxiv.org/abs/1909.11556>`__ for more details.
+        turn_idx: (:obj:`int`, `optional`, defaults to 1721):
+            the tolen_id of the token seprating the conversation turns.  tokenizer.convert_tokens_to_ids('Ġ|') is 1721, that is ' |' token
+        max_turn_embeddings: (:obj:`int`, `optional`, defaults to 150):
+            The maximum number of turns this model might ever be used with.
+        max_speaker_embeddings=10: (:obj:`int`, `optional`, defaults to 10):
+            The maximum number of different speakers this model might ever be used with.
         extra_pos_embeddings: (:obj:`int`, `optional`, defaults to 2):
             How many extra learned positional embeddings to use. Should be set to :obj:`pad_token_id+1`.
         num_labels: (:obj:`int`, `optional`, defaults to 3):
@@ -119,6 +125,7 @@ class BartConfig(PretrainedConfig):
         activation_dropout=0.0,
         extra_pos_embeddings=2,
         activation_function="gelu",
+        turn_idx=1721,
         vocab_size=50265,
         d_model=1024,
         encoder_ffn_dim=4096,
@@ -132,6 +139,8 @@ class BartConfig(PretrainedConfig):
         attention_dropout=0.0,
         dropout=0.1,
         max_position_embeddings=1024,
+        max_turn_embeddings=150,
+        max_speaker_embeddings=10,
         init_std=0.02,
         classifier_dropout=0.0,
         num_labels=3,
@@ -206,6 +215,11 @@ class BartConfig(PretrainedConfig):
         # pos embedding offset
         self.extra_pos_embeddings = extra_pos_embeddings
         # bart has a hack that offsets positional embeddings by 2, other models don't do this
+
+        # parameters related to turn modeling
+        self.turn_idx = turn_idx
+        self.max_turn_embeddings = max_turn_embeddings
+        self.max_speaker_embeddings = max_speaker_embeddings
 
         self.force_bos_token_to_be_generated = force_bos_token_to_be_generated
 

--- a/src/transformers/models/bart/modeling_bart.py
+++ b/src/transformers/models/bart/modeling_bart.py
@@ -308,9 +308,12 @@ class BartEncoder(nn.Module):
         embed_dim = embed_tokens.embedding_dim
         self.embed_scale = math.sqrt(embed_dim) if config.scale_embedding else 1.0
         self.padding_idx = embed_tokens.padding_idx
+        self.turn_idx = config.turn_idx
         self.max_source_positions = config.max_position_embeddings
-
+        self.max_turn_embeddings = config.max_turn_embeddings
+        self.max_speaker_embeddings = config.max_speaker_embeddings
         self.embed_tokens = embed_tokens
+
         if config.static_position_embeddings:
             self.embed_positions = SinusoidalPositionalEmbedding(
                 config.max_position_embeddings, embed_dim, self.padding_idx
@@ -322,6 +325,23 @@ class BartEncoder(nn.Module):
                 self.padding_idx,
                 config.extra_pos_embeddings,
             )
+
+        if self.turn_idx is not None:
+            self.embed_turns = LearnedTurnEmbedding(
+                config.max_turn_embeddings,
+                embed_dim,
+                self.padding_idx,
+                self.turn_idx,
+                config.extra_pos_embeddings,
+            )
+            self.embed_speakers = LearnedSpeakerEmbedding(
+                config.max_speaker_embeddings,
+                embed_dim,
+                self.padding_idx,
+                self.turn_idx,
+                config.extra_pos_embeddings,
+            )
+
         self.layers = nn.ModuleList([EncoderLayer(config) for _ in range(config.encoder_layers)])
         self.layernorm_embedding = LayerNorm(embed_dim) if config.normalize_embedding else nn.Identity()
         # mbart has one extra layer_norm
@@ -352,6 +372,12 @@ class BartEncoder(nn.Module):
         inputs_embeds = self.embed_tokens(input_ids) * self.embed_scale
         embed_pos = self.embed_positions(input_ids)
         x = inputs_embeds + embed_pos
+
+        if self.turn_idx is not None:
+            embed_t = self.embed_turns(input_ids)
+            ebmed_s = self.embed_speakers(input_ids)
+            x = x + embed_t + ebmed_s
+
         x = self.layernorm_embedding(x)
         x = F.dropout(x, p=self.dropout, training=self.training)
 
@@ -814,6 +840,152 @@ class LearnedPositionalEmbedding(nn.Embedding):
             # starts at 0, ends at 1-seq_len
             positions = torch.arange(seq_len, dtype=torch.long, device=self.weight.device)
         return super().forward(positions + self.offset)
+
+class LearnedTurnEmbedding(nn.Embedding):
+    """
+    This module learns Turn position embeddings up to a fixed maximum size. Padding ids are ignored by setting
+    the embedding as 0.0's
+    >>> turn_embs = LearnedTurnEmbedding(150, 3, 1, 1721)
+    >>> text = " Issue | Agent : a  | Customer b b | Agent c c"
+    >>> input_ids = tokenizer([text], return_tensors='pt',padding="max_length", max_length = 20)['input_ids']
+    tensor([[    0, 25422,  1721, 18497,  4832,    10,  1437,  1721, 19458,   741,
+           741,  1721, 18497,   740,   740,     2,     1,     1,     1,     1]])
+    >>> turn_embs.get_turn_ids(input_ids)
+    tensor([[2, 2, 3, 3, 3, 3, 3, 4, 4, 4, 4, 5, 5, 5, 5, 5, 1, 1, 1, 1]])
+    >>> turn_embs.get_turn_ids(input_ids)
+    tensor([[[ 0.3489, -2.3656,  0.4380],
+         [ 0.3489, -2.3656,  0.4380],
+         [ 0.5254, -0.4979,  1.1205],
+         [ 0.5254, -0.4979,  1.1205],
+         [ 0.5254, -0.4979,  1.1205],
+         [ 0.5254, -0.4979,  1.1205],
+         [ 0.5254, -0.4979,  1.1205],
+         [ 0.3352,  2.6305, -1.7175],
+         [ 0.3352,  2.6305, -1.7175],
+         [ 0.3352,  2.6305, -1.7175],
+         [ 0.3352,  2.6305, -1.7175],
+         [-0.7182,  0.7174, -0.1927],
+         [-0.7182,  0.7174, -0.1927],
+         [-0.7182,  0.7174, -0.1927],
+         [-0.7182,  0.7174, -0.1927],
+         [-0.7182,  0.7174, -0.1927],
+         [ 0.0000,  0.0000,  0.0000],
+         [ 0.0000,  0.0000,  0.0000],
+         [ 0.0000,  0.0000,  0.0000],
+         [ 0.0000,  0.0000,  0.0000]]], grad_fn=<EmbeddingBackward>)
+    """
+
+    def __init__(self, num_embeddings: int, embedding_dim: int, padding_idx: int, turn_idx: int, offset: int = 2):
+        self.turn_idx = turn_idx 
+        assert turn_idx is not None
+        assert padding_idx is not None
+        num_embeddings += offset #embedding 0 is reserved for paddings
+        super().__init__(num_embeddings, embedding_dim, padding_idx=padding_idx)
+
+    #turn_idx = tokenizer.convert_tokens_to_ids('Ġ|')
+    #padding_idx = tokenizer.convert_tokens_to_ids('<pad>')
+    def get_turn_ids(self, input_ids):
+        bsz, seq_len = input_ids.shape[:2]
+        turn_ids = torch.ones((bsz, seq_len)).to(input_ids.device) * (input_ids==self.turn_idx)
+        turn_ids = torch.cumsum(turn_ids, dim =1)
+        if turn_ids[0][0] == 0:
+            #turn id starts from 2, since 1 is saved for padding turns due to the hack in BART
+            turn_ids = turn_ids + 2
+        elif  turn_ids[0][0] == 1:
+            turn_ids = turn_ids + 1
+        turn_ids = turn_ids *(input_ids != self.padding_idx) #setting padding turn as 0
+        turn_ids[turn_ids >= self.num_embeddings] = self.num_embeddings-1 # truncate number of turns at self.num_embeddings
+        turn_ids = turn_ids.type(torch.long)
+        return turn_ids
+
+    def forward(self, input_ids, use_cache=False):
+        """Input is expected to be of size [bsz x seqlen].
+        Output is turn embeddings of size [bsz x seqlen x emb_dim]."""
+        # turn id should start from 1, 0 is save for padding_idx
+        turn_ids = self.get_turn_ids(input_ids) #same device as input_ids
+        #turn_ids = turn_ids.to(self.weight.device)
+        return super().forward(turn_ids)
+
+
+class LearnedSpeakerEmbedding(nn.Embedding):
+    """
+    This module learns Turn position embeddings up to a fixed maximum size. Padding ids are ignored by setting
+    the embedding as 0.0's
+    >>> speaker_embs = LearnedSpeakerEmbedding(10, 3, 1, 1721)
+    >>> text = " Issue | Agent : a  | Customer b b | Agent c c"
+    >>> input_ids = tokenizer([text], return_tensors='pt',padding="max_length", max_length = 20)['input_ids']
+    tensor([[    0, 25422,  1721, 18497,  4832,    10,  1437,  1721, 19458,   741,
+           741,  1721, 18497,   740,   740,     2,     1,     1,     1,     1]])
+    >>> speaker_embs.get_speaker_ids(input_ids)
+    tensor([[0, 0, 2, 2, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 4, 1, 1, 1, 1]])
+    >>> speaker_embs(input_ids)
+    tensor([[[-1.0366, -0.7003,  0.2865],
+            [-1.0366, -0.7003,  0.2865],
+            [-1.1948,  0.0561,  0.4046],
+            [-1.1948,  0.0561,  0.4046],
+            [-1.1948,  0.0561,  0.4046],
+            [-1.1948,  0.0561,  0.4046],
+            [-1.1948,  0.0561,  0.4046],
+            [-0.4631,  0.5409, -0.2897],
+            [-0.4631,  0.5409, -0.2897],
+            [-0.4631,  0.5409, -0.2897],
+            [-0.4631,  0.5409, -0.2897],
+            [-1.1511,  1.2626, -0.5360],
+            [-1.1511,  1.2626, -0.5360],
+            [-1.1511,  1.2626, -0.5360],
+            [-1.1511,  1.2626, -0.5360],
+            [-1.1511,  1.2626, -0.5360],
+            [ 0.0000,  0.0000,  0.0000],
+            [ 0.0000,  0.0000,  0.0000],
+            [ 0.0000,  0.0000,  0.0000],
+            [ 0.0000,  0.0000,  0.0000]]], grad_fn=<EmbeddingBackward>)
+    """
+
+    def __init__(self, num_embeddings: int, embedding_dim: int, padding_idx: int, turn_idx: int, offset: int = 2):
+        self.turn_idx = turn_idx
+        assert turn_idx is not None
+        assert padding_idx is not None
+        num_embeddings += offset # embedding 0 is reserved for paddings
+        super().__init__(num_embeddings, embedding_dim, padding_idx=padding_idx)
+
+    #turn_idx = tokenizer.convert_tokens_to_ids('Ġ|')
+    #padding_idx = tokenizer.convert_tokens_to_ids('<pad>')
+    #self = {'padding_idx':padding_idx, 'turn_idx':turn_start_id, 'num_embeddings':10+2}
+    def get_speaker_ids(self, input_ids):
+        arr = torch.zeros(input_ids.shape).to(input_ids.device)
+        idxes_of_turn_token = torch.where(input_ids==self.turn_idx)
+        rows, cols = idxes_of_turn_token[0], idxes_of_turn_token[1]
+        roles_map = {} #batch-wise
+        for i in range(len(rows)):
+            x, y = rows[i].item(), cols[i].item()
+            #next position
+            if i+1 < len(rows):
+                x1, y1 = (rows[i+1].item(), cols[i+1].item())
+            else:
+                x1, y1 = -1, -1
+            role = token_ids[x][y+1].item()
+            if not role in roles_map:
+                roles_map[role] = len(roles_map)+1
+            if x1 == x:
+                arr[x][y:y1] = roles_map[role]
+            else:
+                arr[x][y:] = roles_map[role]
+        if arr[0][0] ==0: # the beginning part is not starting with a speaker symbol e.g. " Issue | Agent: ", the speaker part starts with 2
+            arr[arr>0] += 1
+        elif arr[0][0] ==1: # the beginning part is starting with a speaker symbol e.g. " | Agent: ", shift to start with 2
+            arr += 1
+        arr[arr >= self.num_embeddings] = self.num_embeddings -1 #truncate to make sure not exceeding the num_beddings
+        arr[input_ids==self.padding_idx] = 1 #bart is using padding_idx = 1
+        return arr.type(torch.long)
+
+    def forward(self, input_ids, use_cache=False):
+        """Input is expected to be of size [bsz x seqlen].
+        Output is speaker embeddings of size [bsz x seqlen x emb_dim].
+        """
+        # turn id should start from 1, 0 is save for padding_idx
+        spaker_ids = self.get_speaker_ids(input_ids) #same device as input_ids
+        #turn_ids = turn_ids.to(self.weight.device)
+        return super().forward(spaker_ids)
 
 
 def LayerNorm(normalized_shape, eps=1e-5, elementwise_affine=True):


### PR DESCRIPTION
This PR adds embeddings for turn position embeddings and speaker.


# What does this PR do?

<!--
Congratulations! You've made it this far! You're not quite done yet though.

Once merged, your PR is going to appear in the release notes with the title you set, so make sure it's a great title that fully reflects the extent of your awesome contribution.

Then, please replace this with a description of the change and which issue is fixed (if applicable). Please also include relevant motivation and context. List any dependencies (if any) that are required for this change.

Once you're done, someone will review your PR shortly (see the section "Who can review?" below to tag some potential reviewers). They may suggest changes to make the code even better. If no one reviewed your PR after a week has passed, don't hesitate to post a new comment @-mentioning the same persons---sometimes notifications get lost.
-->

<!-- Remove if not applicable -->

Conversation text transcript has clear structures: list of turns consisting of speaker and utterance. This PR adds embeddings for turn position embeddings and speaker to better model conversation text transcript.

We allow up to 150 turns and up to 10 different speakers. The speaker are interchangeable and is indexed by the order they show up in a conversation for generality. In the specific downstream tasks where the speaker is fixed and each speaker we have similarity, it will be helpful to make sure that different speaker is aligned with a fixed embedding vector.




